### PR TITLE
Improve layout of website on larger and smaller layouts

### DIFF
--- a/about.html
+++ b/about.html
@@ -9,6 +9,7 @@
     <link rel="stylesheet" type="text/css" href="styles/main.css" media="screen" />
     <link rel="stylesheet" type="text/css" href="styles/colours.css" media="screen" />
     <link rel="stylesheet" type="text/css" href="styles/fonts.css" media="screen" />
+    <link rel="stylesheet" type="text/css" href="styles/scaling.css" media="screen" />
 </head>
 <body>
     <nav class="flex-horizontal" id="main-nav">

--- a/contact.html
+++ b/contact.html
@@ -9,6 +9,7 @@
     <link rel="stylesheet" type="text/css" href="styles/main.css" media="screen" />
     <link rel="stylesheet" type="text/css" href="styles/colours.css" media="screen" />
     <link rel="stylesheet" type="text/css" href="styles/fonts.css" media="screen" />
+    <link rel="stylesheet" type="text/css" href="styles/scaling.css" media="screen" />
 </head>
 <body>
     <nav class="flex-horizontal" id="main-nav">

--- a/docs.html
+++ b/docs.html
@@ -9,6 +9,7 @@
     <link rel="stylesheet" type="text/css" href="styles/main.css" media="screen" />
     <link rel="stylesheet" type="text/css" href="styles/colours.css" media="screen" />
     <link rel="stylesheet" type="text/css" href="styles/fonts.css" media="screen" />
+    <link rel="stylesheet" type="text/css" href="styles/scaling.css" media="screen" />
 </head>
 <body>
     <nav class="flex-horizontal" id="main-nav">

--- a/documents/constitution.html
+++ b/documents/constitution.html
@@ -9,6 +9,7 @@
     <link rel="stylesheet" type="text/css" href="styles/main.css" media="screen" />
     <link rel="stylesheet" type="text/css" href="styles/colours.css" media="screen" />
     <link rel="stylesheet" type="text/css" href="styles/fonts.css" media="screen" />
+    <link rel="stylesheet" type="text/css" href="styles/scaling.css" media="screen" />
 </head>
 <body>
     <nav class="flex-horizontal" id="main-nav">

--- a/documents/minutes.html
+++ b/documents/minutes.html
@@ -9,6 +9,7 @@
     <link rel="stylesheet" type="text/css" href="styles/main.css" media="screen" />
     <link rel="stylesheet" type="text/css" href="styles/colours.css" media="screen" />
     <link rel="stylesheet" type="text/css" href="styles/fonts.css" media="screen" />
+    <link rel="stylesheet" type="text/css" href="styles/scaling.css" media="screen" />
 </head>
 <body>
     <nav class="flex-horizontal" id="main-nav">

--- a/documents/regulations.html
+++ b/documents/regulations.html
@@ -9,6 +9,7 @@
     <link rel="stylesheet" type="text/css" href="styles/main.css" media="screen" />
     <link rel="stylesheet" type="text/css" href="styles/colours.css" media="screen" />
     <link rel="stylesheet" type="text/css" href="styles/fonts.css" media="screen" />
+    <link rel="stylesheet" type="text/css" href="styles/scaling.css" media="screen" />
 </head>
 <body>
     <nav class="flex-horizontal" id="main-nav">

--- a/events.html
+++ b/events.html
@@ -9,6 +9,7 @@
     <link rel="stylesheet" type="text/css" href="styles/main.css" media="screen" />
     <link rel="stylesheet" type="text/css" href="styles/colours.css" media="screen" />
     <link rel="stylesheet" type="text/css" href="styles/fonts.css" media="screen" />
+    <link rel="stylesheet" type="text/css" href="styles/scaling.css" media="screen" />
 </head>
 <body>
     <nav class="flex-horizontal" id="main-nav">

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
     <link rel="stylesheet" type="text/css" href="styles/main.css" media="screen" />
     <link rel="stylesheet" type="text/css" href="styles/colours.css" media="screen" />
     <link rel="stylesheet" type="text/css" href="styles/fonts.css" media="screen" />
+    <link rel="stylesheet" type="text/css" href="styles/scaling.css" media="screen" />
 </head>
 <body>
     <nav class="flex-horizontal" id="main-nav">

--- a/resources.html
+++ b/resources.html
@@ -9,6 +9,7 @@
     <link rel="stylesheet" type="text/css" href="styles/main.css" media="screen" />
     <link rel="stylesheet" type="text/css" href="styles/colours.css" media="screen" />
     <link rel="stylesheet" type="text/css" href="styles/fonts.css" media="screen" />
+    <link rel="stylesheet" type="text/css" href="styles/scaling.css" media="screen" />
 </head>
 <body>
     <nav class="flex-horizontal" id="main-nav">

--- a/styles/main.css
+++ b/styles/main.css
@@ -40,16 +40,20 @@ div
     width: 100%;
     max-width: 100%;
 }
+
 #header img
 {
-    margin-top: -110px;
     width: 100%;
     max-width: 100%;
     overflow: visible;
+    position: relative;
+    top: 50%;
+    transform: translateY(-50%);
 }
 
 #main-nav
 {
+    z-index: 3;
     margin-left: var(--site-left);
     margin-right: var(--site-right);
     height: var(--nav-height);

--- a/styles/scaling.css
+++ b/styles/scaling.css
@@ -1,0 +1,47 @@
+@media screen and (max-width: 1200px)
+{
+
+/* Navbar */
+#main-nav li
+{
+    padding-left: calc(2vw + 5px);
+    padding-right: calc(2vw + 5px);
+}
+
+
+}
+
+@media screen and (max-width: 1024px)
+{
+
+/* Navbar */
+#main-nav li
+{
+    padding-left: calc(2vw + 5px);
+    padding-right: calc(2vw + 5px);
+}
+
+#main-nav, #header, .article
+{
+    margin: 0;
+    width: calc(80vw + (2 * (1024px - 100vw)));
+    margin-left: calc(0.5* (100vw - (80vw + (2 * (1024px - 100vw)))));
+}
+
+@media screen and (max-width: 931px)
+{
+
+/* Navbar */
+#main-nav li
+{
+    padding-left: calc(2vw + 5px);
+    padding-right: calc(2vw + 5px);
+}
+
+#main-nav, #header, .article
+{
+    margin: 0;
+    width: 100%;
+}
+
+}

--- a/template
+++ b/template
@@ -9,6 +9,7 @@
     <link rel="stylesheet" type="text/css" href="styles/main.css" media="screen" />
     <link rel="stylesheet" type="text/css" href="styles/colours.css" media="screen" />
     <link rel="stylesheet" type="text/css" href="styles/fonts.css" media="screen" />
+    <link rel="stylesheet" type="text/css" href="styles/scaling.css" media="screen" />
 </head>
 <body>
     <nav class="flex-horizontal" id="main-nav">


### PR DESCRIPTION
Whitespace margin now disappears somewhat smoothly if viewport size is decreased.

Header image now stays centered on larger and smaller screens.

This does not make the website mobile friendly. A higher quality header image would probably be necessary to make the website look nicer on larger screens.