### PR TITLE
Meeting minutes: February 6, 2020.

### DIFF
--- a/content/pages/minutes/feb06_2020.md
+++ b/content/pages/minutes/feb06_2020.md
@@ -1,0 +1,66 @@
+Members Present:
+
+President: Michael Bennett
+
+Projects Manager: James Purdey
+
+CSA Members: Andrew Foisey
+
+Member Regrets:
+
+Derek
+
+William
+
+Meeting called to order at February 6, 2020 4:18.
+
+Andrew motions to accept the agenda. Michael seconds.
+
+1. Association report:
+   1. Plans made to speak with professors regarding spreading information about CSA to students.
+   2. Going to speak with security regarding keys.
+2. Financial report:
+   1. $44.15 on fridge
+   2. Todo: Gain exact figures on bank, shares, & cabinet.
+3. SCC report:
+   1. Lock needs relocking
+   2. Calendar creation is necessary for open-times
+   3. Room rules should be enforced. Including: Volume, hygiene. 
+4. Website report:
+   1. Todo: Fix SEO for google (ufvcsa.ca -> csa.ufv.ca)
+5. Communications report:
+   1. Broadcast stuff over facebook, twitter, instagram
+   2. Fliers on public notice boards
+6. Projects report:
+   1. Nobody is sure what the intention of the openstack project was for (from previous agendas). Not going to include on future agends.
+   2. Looks like there is interest in finishing the current pinboard project.
+   3. Caleb was volunteered to redesign the website.
+   4. Look into getting professor involvement.
+      1. Potential VR thing.
+7. Events report:
+   1. ERA event: students expressed interest.
+   2. Hackathon: Speak with Carl.
+   3. Gaming event would be popular. 
+8. Expansion report:
+   1. There is interest in helping people get interested in co-op.
+   2. There is interest in helping people get prepared for co-op.
+   3. Helping students is difficult due to possible issues with academic dishonesty. Add written rule for not giving answers, only guidance/advice, where appropriate.
+9. Department news:
+   1. IEEE may or may not be happening.
+
+
+
+Decision Items:
+
+1. Probably going to remove the broken computer in a permanent sense.
+2. Potentially sell 3D printer.
+3. Recycle RAM chips.
+4. We don't know where that power supply came from. 
+5. Assume this time until something preferable is found.
+6. Andrew was given key by unanimous vote.
+
+Next meeting will be in three weeks assuming nothing changes.
+
+Meeting adjourned at 5:13PM by Michael.
+
+Meeting minutes created by Michael Bennett.


### PR DESCRIPTION
This adds meeting minutes for February 6, 2020. These minutes are unedited and quite possibly contain errors. Changes should be made in a next commit that would also allow the page to display on the minutes page.