### PR TITLE
Fix minutes for February 27

### DIFF
--- a/content/pages/Minutes.md
+++ b/content/pages/Minutes.md
@@ -5,3 +5,4 @@ path: '/docs/minutes'
 ---
 
 - [Meeting: February 6, 2020](/minutes/feb06_2020)
+- [Meeting: February 27, 2020](/minutes/feb27_2020)

--- a/content/pages/minutes/feb27_2020.md
+++ b/content/pages/minutes/feb27_2020.md
@@ -6,13 +6,13 @@ path: '/minutes/feb27_2020'
 
 ## Members Present:
 
-President: Michael Bennett
-Projects Manager: James Purdey
-Website Manager: Andrew Foisey
+President: Michael Bennett  
+Projects Manager: James Purdey  
+Website Manager: Andrew Foisey  
 
-Member Regrets:
-Derek
-William
+Member Regrets:  
+Derek  
+William  
 
 Michael calls meeting to order at February 27, 2020 4:08. Andrew seconds.
 


### PR DESCRIPTION
Should probably make a Python script that automatically handles the Minutes for us. Alternatively it might actually be possible to do this with React+Javascript.

@MykalMachon Do you think it would be easy enough to make the Minutes.md page automatically list all of the files in `pages/minutes/`?