### PR TITLE
Issue 46 missing favicon

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,7 +1,7 @@
 module.exports = {
   siteMetadata: {
-    title: `UFV Computing Students Association`,
-    description: `The UFV Computing Students Association's website built through open source by the CSA!`,
+    title: `UFV Computing Student Association`,
+    description: `The UFV Computing Student Association's open source website built by the CSA!`,
     author: `@ufvcsa`,
   },
   plugins: [
@@ -46,11 +46,11 @@ module.exports = {
     {
       resolve: `gatsby-plugin-manifest`,
       options: {
-        name: `UFV Computer Science Association`,
+        name: `UFV Computing Student Association`,
         short_name: `ufvcsa`,
         start_url: `/`,
-        background_color: `#663399`,
-        theme_color: `#663399`,
+        background_color: `#FFFFFF`,
+        theme_color: `#00703c`,
         display: `minimal-ui`,
         icon: `src/images/csaLogo_400x400.jpg`, // This path is relative to the root of the site.
         icons: [

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -53,6 +53,23 @@ module.exports = {
         theme_color: `#663399`,
         display: `minimal-ui`,
         icon: `src/images/csaLogo_400x400.jpg`, // This path is relative to the root of the site.
+        icons: [
+          {
+            src: `/favicons/icon-144x144.png`,
+            sizes: `144x144`,
+            type: `image/png`,
+          },
+          {
+            src: `/favicons/icon-192x192.png`,
+            sizes: `192x192`,
+            type: `image/png`,
+          },
+          {
+            src: `/favicons/icon-512x512.png`,
+            sizes: `512x512`,
+            type: `image/png`,
+          },
+        ],
       },
     },
     // this (optional) plugin enables Progressive Web App + Offline functionality


### PR DESCRIPTION
Issue was [this](https://github.com/gatsbyjs/gatsby/issues/12233) and was caused by a conflict with Gatsby and Apache. Also fixed wording (we are the Computing Student Association 🙃) and updated manifest colours.